### PR TITLE
add charset option for windows user

### DIFF
--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -12,6 +12,9 @@ module.exports = (options = {}) ->
   args = ['-jar']
   args.push options.jarPath ? "plantuml.jar"
   args.push '-p'
+  if options.charset
+    args.push "-charset"
+    args.push options.charset
 
   through.obj (file, encoding, callback) ->
     if file.isNull()


### PR DESCRIPTION
I tried gulp-plantuml, but it output garbled diagram.
My situation is following.
- Windows 10
- source file is UTF8.
- source file has multibyte strings.

If gulp-plantuml has charset option, we can aboid that.

``` coffee
  .pipe plantuml(
    charset: 'UTF-8',
    jarPath: './vendor/plantuml.jar'
  )
```

For example, Atom Editor package "PlantUML Viewer" has same option.
